### PR TITLE
Fix syntax error in trading module

### DIFF
--- a/extras/trading/trades_gemini.py
+++ b/extras/trading/trades_gemini.py
@@ -251,7 +251,7 @@ def trade33():
     else:
         return []
 
-def trade34
+def trade34():
     # Inverse Head and Shoulders: Buy when a stock forms an inverse head and shoulders pattern
     ticker = random.choice(tickers)
     if prices[ticker][0] > prices[ticker][2] > prices[ticker][4] and prices[ticker][1] < prices[ticker][3] < prices[ticker][5]:


### PR DESCRIPTION
## Summary
- fix a syntax error in `trades_gemini.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pricer')*

------
https://chatgpt.com/codex/tasks/task_e_6844c52507c88326a99fccdf47604940